### PR TITLE
update-list.sh: add extra escaping

### DIFF
--- a/update-list.sh
+++ b/update-list.sh
@@ -26,9 +26,9 @@ do
 
 	echo "
 #ifdef __NR_$syscall
-	printf('$syscall\t%d\n', __NR_$syscall);
+	printf('$syscall\\t%d\\n', __NR_$syscall);
 #else
-	printf('$syscall\n');
+	printf('$syscall\\n');
 #endif
 "
 done


### PR DESCRIPTION
Else the \n and \t ends up expanded in the .c source file,
at least on debian jessie bash 4.3

Signed-off-by: Riku Voipio <riku.voipio@linaro.org>