### PR TITLE
Add initial LoongArch 64-bit syscall data

### DIFF
--- a/do_all_tables.sh
+++ b/do_all_tables.sh
@@ -50,41 +50,41 @@ do
 
 	case ${arch} in
 	arm)
-		arch=armoabi	extraflags=				generate_table
-		arch=arm	extraflags=-D__ARM_EABI__		generate_table
+		arch=armoabi		extraflags=				generate_table
+		arch=arm		extraflags=-D__ARM_EABI__		generate_table
 		;;
 	loongarch)
 		arch=loongarch64	extraflags=-D_LOONGARCH_SZLONG=64	generate_table
 		;;
 	mips)
-		arch=mipso32	extraflags=-D_MIPS_SIM=_MIPS_SIM_ABI32	generate_table
-		arch=mips64n32	extraflags=-D_MIPS_SIM=_MIPS_SIM_NABI32	generate_table
-		arch=mips64	extraflags=-D_MIPS_SIM=_MIPS_SIM_ABI64	generate_table
+		arch=mipso32		extraflags=-D_MIPS_SIM=_MIPS_SIM_ABI32	generate_table
+		arch=mips64n32		extraflags=-D_MIPS_SIM=_MIPS_SIM_NABI32	generate_table
+		arch=mips64		extraflags=-D_MIPS_SIM=_MIPS_SIM_ABI64	generate_table
 		;;
 	powerpc)
-									generate_table
-		arch=powerpc64						generate_table
+										generate_table
+		arch=powerpc64							generate_table
 		;;
 	riscv)
-		arch=riscv32	extraflags=-D__SIZEOF_POINTER__=4	generate_table
-		arch=riscv64	extraflags=-D__LP64__			generate_table
+		arch=riscv32		extraflags=-D__SIZEOF_POINTER__=4	generate_table
+		arch=riscv64		extraflags=-D__LP64__			generate_table
 		;;
 	s390)
-									generate_table
-		arch=s390x						generate_table
+										generate_table
+		arch=s390x							generate_table
 		;;
 	sparc)
-				extraflags=-D__32bit_syscall_numbers__	generate_table
-		arch=sparc64	extraflags=-D__arch64__			generate_table
+					extraflags=-D__32bit_syscall_numbers__	generate_table
+		arch=sparc64		extraflags=-D__arch64__			generate_table
 		;;
 	tile)
-									generate_table
-		arch=tile64	extraflags="-D__LP64__ -D__tilegx__"	generate_table
+										generate_table
+		arch=tile64		extraflags="-D__LP64__ -D__tilegx__"	generate_table
 		;;
 	x86)
-		arch=i386						generate_table
-		arch=x32	extraflags=-D__ILP32__			generate_table
-		arch=x86_64	extraflags=-D__LP64__			generate_table
+		arch=i386							generate_table
+		arch=x32		extraflags=-D__ILP32__			generate_table
+		arch=x86_64		extraflags=-D__LP64__			generate_table
 		;;
 	*)
 		generate_table

--- a/do_all_tables.sh
+++ b/do_all_tables.sh
@@ -53,6 +53,9 @@ do
 		arch=armoabi	extraflags=				generate_table
 		arch=arm	extraflags=-D__ARM_EABI__		generate_table
 		;;
+	loongarch)
+		arch=loongarch64	extraflags=-D_LOONGARCH_SZLONG=64	generate_table
+		;;
 	mips)
 		arch=mipso32	extraflags=-D_MIPS_SIM=_MIPS_SIM_ABI32	generate_table
 		arch=mips64n32	extraflags=-D_MIPS_SIM=_MIPS_SIM_NABI32	generate_table

--- a/do_all_tables.sh
+++ b/do_all_tables.sh
@@ -58,22 +58,13 @@ do
 		arch=mips64n32	extraflags=-D_MIPS_SIM=_MIPS_SIM_NABI32	generate_table
 		arch=mips64	extraflags=-D_MIPS_SIM=_MIPS_SIM_ABI64	generate_table
 		;;
-	tile)
-									generate_table
-		arch=tile64	extraflags="-D__LP64__ -D__tilegx__"	generate_table
-		;;
-	x86)
-		arch=i386	                        		generate_table
-		arch=x32 	extraflags=-D__ILP32__			generate_table
-		arch=x86_64	extraflags=-D__LP64__			generate_table
-		;;
-	riscv)
-		arch=riscv32	extraflags=-D__SIZEOF_POINTER__=4       generate_table
-		arch=riscv64	extraflags=-D__LP64__			generate_table
-		;;
 	powerpc)
 									generate_table
 		arch=powerpc64						generate_table
+		;;
+	riscv)
+		arch=riscv32	extraflags=-D__SIZEOF_POINTER__=4	generate_table
+		arch=riscv64	extraflags=-D__LP64__			generate_table
 		;;
 	s390)
 									generate_table
@@ -82,6 +73,15 @@ do
 	sparc)
 				extraflags=-D__32bit_syscall_numbers__	generate_table
 		arch=sparc64	extraflags=-D__arch64__			generate_table
+		;;
+	tile)
+									generate_table
+		arch=tile64	extraflags="-D__LP64__ -D__tilegx__"	generate_table
+		;;
+	x86)
+		arch=i386						generate_table
+		arch=x32	extraflags=-D__ILP32__			generate_table
+		arch=x86_64	extraflags=-D__LP64__			generate_table
 		;;
 	*)
 		generate_table

--- a/tables/syscalls-loongarch64
+++ b/tables/syscalls-loongarch64
@@ -1,0 +1,599 @@
+_llseek
+_newselect
+_sysctl
+accept	202
+accept4	242
+access
+acct	89
+add_key	217
+adjtimex	171
+alarm
+arc_gettls
+arc_settls
+arc_usr_cmpxchg
+arch_prctl
+arm_fadvise64_64
+atomic_barrier
+atomic_cmpxchg_32
+bdflush
+bind	200
+bpf	280
+brk	214
+cachectl
+cacheflush
+capget	90
+capset	91
+chdir	49
+chmod
+chown
+chown32
+chroot	51
+clock_adjtime	266
+clock_adjtime64
+clock_getres	114
+clock_getres_time64
+clock_gettime	113
+clock_gettime64
+clock_nanosleep	115
+clock_nanosleep_time64
+clock_settime	112
+clock_settime64
+clone	220
+clone2
+clone3	435
+close	57
+close_range	436
+connect	203
+copy_file_range	285
+creat
+create_module
+delete_module	106
+dipc
+dup	23
+dup2
+dup3	24
+epoll_create
+epoll_create1	20
+epoll_ctl	21
+epoll_ctl_old
+epoll_pwait	22
+epoll_pwait2	441
+epoll_wait
+epoll_wait_old
+eventfd
+eventfd2	19
+exec_with_loader
+execv
+execve	221
+execveat	281
+exit	93
+exit_group	94
+faccessat	48
+faccessat2	439
+fadvise64	223
+fadvise64_64
+fallocate	47
+fanotify_init	262
+fanotify_mark	263
+fchdir	50
+fchmod	52
+fchmodat	53
+fchown	55
+fchown32
+fchownat	54
+fcntl	25
+fcntl64
+fdatasync	83
+fgetxattr	10
+finit_module	273
+flistxattr	13
+flock	32
+fork
+fp_udfiex_crtl
+fremovexattr	16
+fsconfig	431
+fsetxattr	7
+fsmount	432
+fsopen	430
+fspick	433
+fstat	80
+fstat64
+fstatat64
+fstatfs	44
+fstatfs64
+fsync	82
+ftruncate	46
+ftruncate64
+futex	98
+futex_time64
+futimesat
+get_kernel_syms
+get_mempolicy	236
+get_robust_list	100
+get_thread_area
+getcpu	168
+getcwd	17
+getdents
+getdents64	61
+getdomainname
+getdtablesize
+getegid	177
+getegid32
+geteuid	175
+geteuid32
+getgid	176
+getgid32
+getgroups	158
+getgroups32
+gethostname
+getitimer	102
+getpagesize
+getpeername	205
+getpgid	155
+getpgrp
+getpid	172
+getpmsg
+getppid	173
+getpriority	141
+getrandom	278
+getresgid	150
+getresgid32
+getresuid	148
+getresuid32
+getrlimit
+getrusage	165
+getsid	156
+getsockname	204
+getsockopt	209
+gettid	178
+gettimeofday	169
+getuid	174
+getuid32
+getunwind
+getxattr	8
+getxgid
+getxpid
+getxuid
+idle
+init_module	105
+inotify_add_watch	27
+inotify_init
+inotify_init1	26
+inotify_rm_watch	28
+io_cancel	3
+io_destroy	1
+io_getevents	4
+io_pgetevents	292
+io_pgetevents_time64
+io_setup	0
+io_submit	2
+io_uring_enter	426
+io_uring_register	427
+io_uring_setup	425
+ioctl	29
+ioperm
+iopl
+ioprio_get	31
+ioprio_set	30
+ipc
+kcmp	272
+kern_features
+kexec_file_load	294
+kexec_load	104
+keyctl	219
+kill	129
+landlock_add_rule	445
+landlock_create_ruleset	444
+landlock_restrict_self	446
+lchown
+lchown32
+lgetxattr	9
+link
+linkat	37
+listen	201
+listxattr	11
+llistxattr	12
+lookup_dcookie	18
+lremovexattr	15
+lseek	62
+lsetxattr	6
+lstat
+lstat64
+madvise	233
+mbind	235
+membarrier	283
+memfd_create	279
+memfd_secret
+memory_ordering
+migrate_pages	238
+mincore	232
+mkdir
+mkdirat	34
+mknod
+mknodat	33
+mlock	228
+mlock2	284
+mlockall	230
+mmap	222
+mmap2
+modify_ldt
+mount	40
+mount_setattr	442
+move_mount	429
+move_pages	239
+mprotect	226
+mq_getsetattr	185
+mq_notify	184
+mq_open	180
+mq_timedreceive	183
+mq_timedreceive_time64
+mq_timedsend	182
+mq_timedsend_time64
+mq_unlink	181
+mremap	216
+msgctl	187
+msgget	186
+msgrcv	188
+msgsnd	189
+msync	227
+multiplexer
+munlock	229
+munlockall	231
+munmap	215
+name_to_handle_at	264
+nanosleep	101
+newfstatat	79
+nfsservctl	42
+nice
+old_adjtimex
+old_getpagesize
+oldfstat
+oldlstat
+oldolduname
+oldstat
+oldumount
+olduname
+open
+open_by_handle_at	265
+open_tree	428
+openat	56
+openat2	437
+or1k_atomic
+osf_adjtime
+osf_afs_syscall
+osf_alt_plock
+osf_alt_setsid
+osf_alt_sigpending
+osf_asynch_daemon
+osf_audcntl
+osf_audgen
+osf_chflags
+osf_execve
+osf_exportfs
+osf_fchflags
+osf_fdatasync
+osf_fpathconf
+osf_fstat
+osf_fstatfs
+osf_fstatfs64
+osf_fuser
+osf_getaddressconf
+osf_getdirentries
+osf_getdomainname
+osf_getfh
+osf_getfsstat
+osf_gethostid
+osf_getitimer
+osf_getlogin
+osf_getmnt
+osf_getrusage
+osf_getsysinfo
+osf_gettimeofday
+osf_kloadcall
+osf_kmodcall
+osf_lstat
+osf_memcntl
+osf_mincore
+osf_mount
+osf_mremap
+osf_msfs_syscall
+osf_msleep
+osf_mvalid
+osf_mwakeup
+osf_naccept
+osf_nfssvc
+osf_ngetpeername
+osf_ngetsockname
+osf_nrecvfrom
+osf_nrecvmsg
+osf_nsendmsg
+osf_ntp_adjtime
+osf_ntp_gettime
+osf_old_creat
+osf_old_fstat
+osf_old_getpgrp
+osf_old_killpg
+osf_old_lstat
+osf_old_open
+osf_old_sigaction
+osf_old_sigblock
+osf_old_sigreturn
+osf_old_sigsetmask
+osf_old_sigvec
+osf_old_stat
+osf_old_vadvise
+osf_old_vtrace
+osf_old_wait
+osf_oldquota
+osf_pathconf
+osf_pid_block
+osf_pid_unblock
+osf_plock
+osf_priocntlset
+osf_profil
+osf_proplist_syscall
+osf_reboot
+osf_revoke
+osf_sbrk
+osf_security
+osf_select
+osf_set_program_attributes
+osf_set_speculative
+osf_sethostid
+osf_setitimer
+osf_setlogin
+osf_setsysinfo
+osf_settimeofday
+osf_shmat
+osf_signal
+osf_sigprocmask
+osf_sigsendset
+osf_sigstack
+osf_sigwaitprim
+osf_sstk
+osf_stat
+osf_statfs
+osf_statfs64
+osf_subsys_info
+osf_swapctl
+osf_swapon
+osf_syscall
+osf_sysinfo
+osf_table
+osf_uadmin
+osf_usleep_thread
+osf_uswitch
+osf_utc_adjtime
+osf_utc_gettime
+osf_utimes
+osf_utsname
+osf_wait4
+osf_waitid
+pause
+pciconfig_iobase
+pciconfig_read
+pciconfig_write
+perf_event_open	241
+perfctr
+perfmonctl
+personality	92
+pidfd_getfd	438
+pidfd_open	434
+pidfd_send_signal	424
+pipe
+pipe2	59
+pivot_root	41
+pkey_alloc	289
+pkey_free	290
+pkey_mprotect	288
+poll
+ppoll	73
+ppoll_time64
+prctl	167
+pread64	67
+preadv	69
+preadv2	286
+prlimit64	261
+process_madvise	440
+process_vm_readv	270
+process_vm_writev	271
+pselect6	72
+pselect6_time64
+ptrace	117
+pwrite64	68
+pwritev	70
+pwritev2	287
+query_module
+quotactl	60
+quotactl_fd	443
+read	63
+readahead	213
+readdir
+readlink
+readlinkat	78
+readv	65
+reboot	142
+recv
+recvfrom	207
+recvmmsg	243
+recvmmsg_time64
+recvmsg	212
+remap_file_pages	234
+removexattr	14
+rename
+renameat
+renameat2	276
+request_key	218
+restart_syscall	128
+riscv_flush_icache
+rmdir
+rseq	293
+rt_sigaction	134
+rt_sigpending	136
+rt_sigprocmask	135
+rt_sigqueueinfo	138
+rt_sigreturn	139
+rt_sigsuspend	133
+rt_sigtimedwait	137
+rt_sigtimedwait_time64
+rt_tgsigqueueinfo	240
+rtas
+s390_guarded_storage
+s390_pci_mmio_read
+s390_pci_mmio_write
+s390_runtime_instr
+s390_sthyi
+sched_get_affinity
+sched_get_priority_max	125
+sched_get_priority_min	126
+sched_getaffinity	123
+sched_getattr	275
+sched_getparam	121
+sched_getscheduler	120
+sched_rr_get_interval	127
+sched_rr_get_interval_time64
+sched_set_affinity
+sched_setaffinity	122
+sched_setattr	274
+sched_setparam	118
+sched_setscheduler	119
+sched_yield	124
+seccomp	277
+select
+semctl	191
+semget	190
+semop	193
+semtimedop	192
+semtimedop_time64
+send
+sendfile	71
+sendfile64
+sendmmsg	269
+sendmsg	211
+sendto	206
+set_mempolicy	237
+set_robust_list	99
+set_thread_area
+set_tid_address	96
+setdomainname	162
+setfsgid	152
+setfsgid32
+setfsuid	151
+setfsuid32
+setgid	144
+setgid32
+setgroups	159
+setgroups32
+sethae
+sethostname	161
+setitimer	103
+setns	268
+setpgid	154
+setpgrp
+setpriority	140
+setregid	143
+setregid32
+setresgid	149
+setresgid32
+setresuid	147
+setresuid32
+setreuid	145
+setreuid32
+setrlimit
+setsid	157
+setsockopt	208
+settimeofday	170
+setuid	146
+setuid32
+setxattr	5
+sgetmask
+shmat	196
+shmctl	195
+shmdt	197
+shmget	194
+shutdown	210
+sigaction
+sigaltstack	132
+signal
+signalfd
+signalfd4	74
+sigpending
+sigprocmask
+sigreturn
+sigsuspend
+socket	198
+socketcall
+socketpair	199
+splice	76
+spu_create
+spu_run
+ssetmask
+stat
+stat64
+statfs	43
+statfs64
+statx	291
+stime
+subpage_prot
+swapcontext
+swapoff	225
+swapon	224
+switch_endian
+symlink
+symlinkat	36
+sync	81
+sync_file_range	84
+sync_file_range2
+syncfs	267
+sys_debug_setcontext
+syscall
+sysfs
+sysinfo	179
+syslog	116
+sysmips
+tee	77
+tgkill	131
+time
+timer_create	107
+timer_delete	111
+timer_getoverrun	109
+timer_gettime	108
+timer_gettime64
+timer_settime	110
+timer_settime64
+timerfd
+timerfd_create	85
+timerfd_gettime	87
+timerfd_gettime64
+timerfd_settime	86
+timerfd_settime64
+times	153
+tkill	130
+truncate	45
+truncate64
+ugetrlimit
+umask	166
+umount
+umount2	39
+uname	160
+unlink
+unlinkat	35
+unshare	97
+uselib
+userfaultfd	282
+ustat
+utime
+utimensat	88
+utimensat_time64
+utimes
+utrap_install
+vfork
+vhangup	58
+vm86
+vm86old
+vmsplice	75
+wait4	260
+waitid	95
+waitpid
+write	64
+writev	66


### PR DESCRIPTION
Although this architecture is not merged upstream yet, it's remarkably generic syscall-wise, so add this info early for enabling more bring-up work downstream.

Fixes #19.