### PR TITLE
Add handling for compilation failures of list-syscalls.c

### DIFF
--- a/scripts/update-tables.sh
+++ b/scripts/update-tables.sh
@@ -66,6 +66,8 @@ drop_bad_entries()
 
 generate_table()
 {
+	rm -f ${TEMP}/list-syscalls.c ${TEMP}/list-syscalls
+
 	echo -n "$arch "
 	echo $arch >> ${DATADIR}/architectures-present-in-kernel.text
 
@@ -77,7 +79,12 @@ generate_table()
 	generate_list_syscalls_c >${TEMP}/list-syscalls.c
 	gcc list-syscalls.c -U__LP64__ -U__ILP32__ -U__i386__ -D${arch^^} \
 		-D__${arch}__ ${extraflags} -I headers/usr/include/ -o list-syscalls &>/dev/null
-	./list-syscalls > "${DATADIR}/tables/syscalls-$arch"
+
+	if [ $? -eq 0 ]; then
+		./list-syscalls > "${DATADIR}/tables/syscalls-$arch"
+	else
+		echo -e "\n\nFailed to compile list-syscalls for $arch\n"
+	fi
 }
 
 generate_list_syscalls_c()


### PR DESCRIPTION
Since no error checking was previously being performed on the gcc command that generates the list-syscalls executable, delete the list-syscalls.c and list-syscalls executable between architecture iterations. Also, add an "if succeeded" around the execution of ./list-syscalls to avoid an execution error.  Adding these checks ensures that a previous architecture's list-syscalls isn't erroneously used for an architecture that fails to compile.

Without this patch, the previous architecture's (i386's) list-syscalls was erroneously used for x32, and thus the i386 syscalls and syscall numbers were being placed in the x32 table.

This was motivated by trying to compile x32 on a Fedora x86_64 system.  The Fedora kernel currently doesn't support x32 [1]. I was unable to find a Fedora userspace package that provides stubs-x32.h, and various internet discussions mention that x32 is _not_ supported by Fedora.

Below is the gcc error when compiling x32 on Fedora that is being suppressed:

```
In file included from /usr/include/features.h:535,
                 from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/stdio.h:28,
                 from list-syscalls.c:2:
/usr/include/gnu/stubs.h:13:11: fatal error: gnu/stubs-x32.h: No such file or directory
   13 | # include <gnu/stubs-x32.h>
      |           ^~~~~~~~~~~~~~~~~
compilation terminated.
```

[1] https://src.fedoraproject.org/rpms/kernel/blob/rawhide/f/kernel-x86_64-fedora.config#_9367